### PR TITLE
Clarify setup a little

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It's a bit complicated.
 - a proxy capable of modifying requests based on hostname, like [Charles](http://www.charlesproxy.com/) or hoxy – `npm install -g hoxy`)
 - Possibly OSX – I haven't tried on other platforms
 
-You'll need to be able host a local server and give it a different hostname than `localhost` - this will be your *network host*. I'd recommend `something-origin.dev`. You'll use `something.dev` (so, no `-origin` bit) to hit the service worker. This second host is your *local host*.
+You'll need to be able host a local server and give it a different hostname than `localhost` - this will be your *network host*. I'd recommend `demosite-origin.dev`. You'll use `demosite.dev` (so, no `-origin` bit) to hit the service worker. This second host is your *local host*.
 
 I built [`distra`](https://github.com/phuu/distra) which can do this, but there are other ways. You could also use a remote server (I think, not tried).
 
@@ -32,16 +32,30 @@ Here's an image that might help. It might not.
 
 ### Starting it up
 
-1. Start the *network origin server*. You should be able to access it as you would any other website.
+Using distra makes the following setup a lot easier:
+
+```bash
+# Run this in a seperate terminal or in the background
+distra 80
+
+distra add serviceworker-resources.dev
+cd site
+distra add demosite.dev
+distra add demosite-origin.dev
+```
+
+1. Start the *network origin server* to serve the `site/` directory. You should be able to access it as you would any other website, ie. opening [http://demosite-origin.dev/](http://demosite-origin.dev/) should show you the "Regular old index page". (Covered by distra)
 2. Edit your proxy's setup to rewrite requests to the *local origin* to go to the ServiceWorker (`localhost:5678` for example), which can then pretend it's the *local origin* and make requests to the *network origin*. In Charles, use a Rewrite (Tools > Rewrite) that modifies the Host. If you're using hoxy, there's some setup in [`hoxy-rules.txt`](hoxy-rules.txt).
 3. If you're using hoxy, start it in the project's directory. It will read the `hoxy-rules.txt` file.
-4. Configure your machine/browser's HTTP proxy settings to go through the proxy. By default with `hoxy`, this will be `localhost:8080`.
-5. Start the SevicerWorker server. Run `node --harmony server.js 5678 http://your.local.origin/ http://your.network.origin/ worker.js`.
-6. Install the unpacked Chrome extension from the devtools folder of this project. You *must* have devtools open when testing this stuff; the devtools extension connects to the ServiceWorker server via WebSocket to inform it when a navigation is occuring.
+4. Configure your machine/browser's HTTP proxy settings to go through the proxy. By default with `hoxy`, this will be `localhost:8080`. [Screenshot](https://www.dropbox.com/s/zl8jjukj7poqlkc/Screenshot%202014-01-06%2012.01.51.png)
+5. Install the dependencies with `npm install`.
+6. Start the SevicerWorker server. Run `node --harmony server.js 5678 http://demosite.dev/ http://demosite-origin.dev/ worker.js`.
+7. Install the unpacked Chrome extension from the `devtools/` folder of this project. You *must* have devtools open when testing this stuff; the devtools extension connects to the ServiceWorker server via WebSocket to inform it when a navigation is occuring.
+8. Start the *ServiceWorker resources server* to serve the root of the project directory under the name `serviceworker-resource.dev`. (Covered by distra)
 
-You should now be able to visit the local origin and have it proxy through to the network origin, and see logging from the ServiceWorker coming from node. They'll be prefixed with `sw: `.
+You should now be able to visit the **local** origin ([http://demosite.dev/](http://demosite.dev/)) and have it proxy through to the **network** origin, and see logging from the ServiceWorker coming from node. They'll be prefixed with `sw: `.
 
-You can now add to the `worker.js` to play with the API. Lots of stuff it missing, but the core request interception, caching and response APIs are there.
+You can now add to the `worker.js` to play with the API. Lots of stuff is missing, but the core request interception, caching and response APIs are there.
 
 ### Worker activation flow
 


### PR DESCRIPTION
Added some hints that made it easier (at least for me) to get this running. Even though you can be flexible with the naming, it's surely easier for someone setting this up to work with a consistent schema for the host names since the nomenclature is difficult enough, so I renamed everything to `demosite[-origin].dev`.

I hope this helps a bit.
