### PR TITLE
Throw error when respondWith called twice in single fetch event.

### DIFF
--- a/spec/FetchEvent.js
+++ b/spec/FetchEvent.js
@@ -19,6 +19,10 @@ function FetchEvent(type, request, _responder) {
 }
 
 FetchEvent.prototype.respondWith = function (response) {
+    if (this._isStopped()) {
+        throw new Error('respondWith() can only be called once per fetch event');
+    }
+
     if (!_instanceOf(response, Response) && !_instanceOf(response, Promise)) {
         throw new TypeError('respondWith requires a Reponse or a Promise');
     }


### PR DESCRIPTION
Fixes #35
