### PR TITLE
Replace remaing demo mentions and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ServiceWorker demo
+# ServiceWorker Polyfill
 
 This is a polyfill for the [ServiceWorker](https://github.com/slightlyoff/ServiceWorker) specification. The idea is to enable exploration of the ServiceWorker API and the implications it has for users, applications and developer workflow.
 
-**NOTE:** This may be broken for you. Please [submit an issue](https://github.com/phuu/serviceworker-demo/issues/new).
+**NOTE:** This may be broken for you. Please [submit an issue](https://github.com/phuu/serviceworker-polyfill/issues/new).
 
 ## Setup
 
@@ -46,4 +46,4 @@ There's also registration, install and activation steps. Check the spec for this
 
 ## Contributing
 
-[Submit an issue](https://github.com/phuu/serviceworker-demo/issues/new) or pull request!
+[Submit an issue](https://github.com/phuu/serviceworker-polyfill/issues/new) or pull request!

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var browserLauncher = require('./browserLauncher');
 var startServer = require('./server').startServer;
 var chalk = require('chalk');
 
-var issueLink = chalk.blue('https://github.com/phuu/serviceworker-demo/issues/new');
+var issueLink = chalk.blue('https://github.com/phuu/serviceworker-polyfill/issues/new');
 
 var argvConfig = require('optimist')
     .usage('ServiceWorker polyfill.\nPlease submit issues at ' + issueLink)


### PR DESCRIPTION
Noticed an old URL show up on the screen during the demo. While there are redirects and all, it's nice to be consistent.
